### PR TITLE
Fix Exception: Cannot find reverse relation for model

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -517,7 +517,7 @@ def get_form(model, converter,
     mapper = model._sa_class_manager.mapper
     field_args = field_args or {}
 
-    properties = ((p.key, p) for p in mapper.iterate_properties)
+    properties = ((p.key, p) for p in mapper.attrs)
 
     if only:
         def find(name):

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -366,7 +366,7 @@ class ModelView(BaseModelView):
         if model is None:
             model = self.model
 
-        return model._sa_class_manager.mapper.iterate_properties
+        return model._sa_class_manager.mapper.attrs
 
     def _apply_path_joins(self, query, joins, path, inner_join=True):
         """


### PR DESCRIPTION
SQLAlchemy 2.0.2 removed the invocation of registry.configure() from Mapper.iterate_properties causing this problem.

https://docs.sqlalchemy.org/changelog/changelog_20.html#change-45fe5664c88893d899c991ca3675142c

Observed as test failures in:

flask_admin/tests/sqla/test_basic.py
flask_admin/tests/sqla/test_form_rules.py
flask_admin/tests/sqla/test_inlineform.py